### PR TITLE
Move require("trash.plugins") up

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,7 +1,7 @@
 require("trash.utils")
+require("trash.plugins")
 require("trash.options")
 require("trash.mappings")
-require("trash.plugins")
 require("trash.colorscheme")
 require("trash.treesitter")
 require("trash.which-key")

--- a/lua/trash/lsp/init.lua
+++ b/lua/trash/lsp/init.lua
@@ -33,7 +33,7 @@ m.setup({
 		"taplo",
 		"marksman",
 		"dockerls",
-		"cssmodulesls",
+		"cssmodules_ls",
 		"volar",
 		"angularls",
 	},
@@ -48,7 +48,7 @@ if not cmp_nvim_lsp then
 end
 
 local capabilities = vim.lsp.protocol.make_client_capabilities()
-capabilities = cmp_nvim_lsp.update_capabilities(capabilities)
+capabilities = cmp_nvim_lsp.default_capabilities
 
 local opts = {
 	capabilities = capabilities,


### PR DESCRIPTION
move require("trash.plugins") above, to avoid an error when launching a clean neovim installation with this configuration. you'd get an error otherwise because of the require command in require("trash.options"). trash.plugins should install all the plugins automagically.