### PR TITLE
fix: hide empty hover messages from lsp servers

### DIFF
--- a/lua/config/lsp/config.lua
+++ b/lua/config/lsp/config.lua
@@ -29,9 +29,22 @@ local config = {
 
 vim.diagnostic.config(config)
 
-vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, {
-	border = "rounded",
-})
+vim.lsp.handlers["textDocument/hover"] = function(_, result, ctx, conf)
+	if not (result and result.contents) then
+		return
+	end
+
+	local content = vim.lsp.util.convert_input_to_markdown_lines(result.contents)
+	content = vim.lsp.util.trim_empty_lines(content)
+
+	if vim.tbl_isempty(content) then
+		return
+	end
+
+	return vim.lsp.with(vim.lsp.handlers.hover, {
+		border = "rounded",
+	})(_, result, ctx, conf)
+end
 
 vim.lsp.handlers["textDocument/signatureHelp"] = vim.lsp.with(vim.lsp.handlers.signature_help, {
 	border = "rounded",


### PR DESCRIPTION
When multiple LSP servers are attached to a buffer, and we call the hover function (K), vim-notify usually displays several `No information available` messages. This change avoids that behaviour by skipping empty results.