### PR TITLE
fix: 🐛 bufferline right-click closes nvim entirely

### DIFF
--- a/lua/config/bufferline.lua
+++ b/lua/config/bufferline.lua
@@ -1,6 +1,7 @@
 import("bufferline", function(bufferline)
 	bufferline.setup({
 		options = {
+			right_mouse_command = "Bdelete %d",
 			buffer_close_icon = "",
 			diagnostics = "nvim_lsp",
 			diagnostics_indicator = function(_, level)


### PR DESCRIPTION
Uses the already installed [bufdelete plugin](https://github.com/famiu/bufdelete.nvim) to cleverly close buffers. Without it, it defaults to force closing nvim entirely if there's no other buffers open. 

Say you have a buffer you want to close and there is also an empty new buffer next to it, when you right-click the buffer you're on, it will close vim entirely.

![gif](https://i.imgur.com/rxFp744.gif)

