### PR TITLE
Fix mason-null-ls configuration

### DIFF
--- a/lua/config/lsp/null-ls.lua
+++ b/lua/config/lsp/null-ls.lua
@@ -1,21 +1,14 @@
-import({ "mason-null-ls", "null-ls", "mason-null-ls.automatic_setup" }, function(modules)
+import({ "mason-null-ls", "null-ls" }, function(modules)
 	local mason_null_ls = modules["mason-null-ls"]
-	local mason_automatic_setup = modules["mason-null-ls.automatic_setup"]
 	local null_ls = modules["null-ls"]
 
 	mason_null_ls.setup({
 		ensure_installed = { "stylua", "prettier" },
-	})
-
-	mason_null_ls.setup_handlers({
-		function(source_name, methods)
-			-- all sources with no handler get passed here
-			-- Keep original functionality of `automatic_setup = true`
-			mason_automatic_setup(source_name, methods)
-		end,
-		stylua = function()
-			null_ls.register(null_ls.builtins.formatting.stylua)
-		end,
+		handlers = {
+			stylua = function()
+				null_ls.register(null_ls.builtins.formatting.stylua)
+			end,
+		},
 	})
 
 	-- will setup any installed and configured sources above


### PR DESCRIPTION
The mason-null-ls removed the automatic_setup function in favor of a handlers property on the setup function.